### PR TITLE
select the name of the current category

### DIFF
--- a/server/routes/admin/articles/articles.js
+++ b/server/routes/admin/articles/articles.js
@@ -36,9 +36,16 @@ router.get('/edit/:articleId', ensureAuthenticated, (req, res) => {
     const { articleId } = req.params;
     const categoriesCallback = (error, categories) => {
         articleCallback = (error, article) => {
+            let CategorySelected = "";
+            categories.map((category)=>{
+                if(article.category.equals(category._id)){
+                    CategorySelected=category.title;
+                }
+            })
             res.render("admin-edit-article", {
                 article: article,
-                categories: categories
+                categories: categories,
+                CategorySelected:CategorySelected
             });
         };
         articleClient.findArticleById(articleId, articleCallback);

--- a/server/views/admin-edit-article.hbs
+++ b/server/views/admin-edit-article.hbs
@@ -35,7 +35,7 @@
     <div class="form-group has-success">
       <label class="text-success mt-2"> Categories:</label>
       <select name="category" class="form-control mb-4">
-        <option value={{this.article.category}} selected>Choose a Category</option>
+        <option value={{this.article.category}} selected>{{this.CategorySelected}}</option>
         {{#each categories}}
         <option value={{this._id}}>{{ this.title }}</option>
         {{/each}}


### PR DESCRIPTION
When we want to update an article, category title changed to be the title of the current category instead of choose category